### PR TITLE
Fix 500 error #4

### DIFF
--- a/Resources/views/index.html.twig
+++ b/Resources/views/index.html.twig
@@ -2,7 +2,6 @@
 {% import "macros/widgets.html.twig" as widgets %}
 {% import "macros/datatables.html.twig" as tables %}
 {% import "macros/toolbar.html.twig" as toolbar %}
-{% import "macros/actions.html.twig" as actions %}
 
 {% set columns = {
     'alias': 'alwaysVisible',


### PR DESCRIPTION
Cause: there's a reference to a non-existent template:

```
[2020-02-02 00:30:18] request.CRITICAL: Uncaught PHP Exception Twig\Error\LoaderError: "Unable to find template "macros/actions.html.twig" (looked into: /opt/kimai/templates, /opt/kimai/vendor/symfony/twig-bridge/Resources/views/Form) in "@ReadOnlyAccess/index.html.twig" at line 5." at /opt/kimai/vendor/twig/twig/src/Loader/FilesystemLoader.php line 250 {"exception":"[object] (Twig\\Error\\LoaderError(code: 0): Unable to find template \"macros/actions.html.twig\" (looked into: /opt/kimai/templates, /opt/kimai/vendor/symfony/twig-bridge/Resources/views/Form) in \"@ReadOnlyAccess/index.html.twig\" at line 5. at /opt/kimai/vendor/twig/twig/src/Loader/FilesystemLoader.php:250)"} []
[2020-02-02 00:30:18] security.DEBUG: Stored the security token in the session. {"key":"_security_secured_area"} []
```

So a solution:

- edit the file `plugins/ReadOnlyAccessBundle/Resources/views/index.html.twig`
- remove the line `{% import "macros/actions.html.twig" as actions %}`
- clear an warmup the cache:

```bash
cd kimai/
bin/console cache:clear
bin/console cache:warmup
```

Then you get the page back